### PR TITLE
fix the check_gemc_box

### DIFF
--- a/aiida_raspa/utils/inspection_tools.py
+++ b/aiida_raspa/utils/inspection_tools.py
@@ -179,7 +179,6 @@ def check_gemc_box(workchain, calc):
 
     if not all(box_one_stat and box_two_stat):
         workchain.report("GEMC box is NOT converged: repeating with increase box...")
-        workchain.ctx.inputs.retrieved_parent_folder = calc.outputs['retrieved']
         # Fixing the issue.
         if not all(box_one_stat):
             workchain.ctx.inputs.parameters = increase_box_lenght(workchain.ctx.inputs.parameters, Str("box_one"),


### PR DESCRIPTION
If we are restarting the calculation, `RASPA` reads the box properties from the restart file and therefore, increasing the box length within the input file will not be taken into account. 

This PR removes the restart from `check_gemc_box` within the `inspection_tools` to avoid happening the above-mentioned issue. 