### PR TITLE
RaspaBaseWorkChain: enable restarts due to timeout:

### DIFF
--- a/aiida_raspa/parsers/__init__.py
+++ b/aiida_raspa/parsers/__init__.py
@@ -44,6 +44,14 @@ class RaspaParser(Parser):
                 system,
                 fname)
 
+            # Check for possible errors
+            with open(output_abs_path) as fobj:
+                content = fobj.read()
+                if "Starting simulation" not in content:
+                    return self.exit_codes.ERROR_SIMULATION_DID_NOT_START
+                if "Simulation finished" not in content:
+                    return self.exit_codes.TIMEOUT
+
             # parse output parameters and warnings
             parsed_parameters, parsed_warnings = parse_base_output(output_abs_path, system_name, ncomponents)
             output_parameters[system_name] = parsed_parameters

--- a/aiida_raspa/utils/__init__.py
+++ b/aiida_raspa/utils/__init__.py
@@ -3,5 +3,7 @@
 from __future__ import absolute_import
 from .base_parser import parse_base_output
 from .base_input_generator import RaspaInput
-from .inspection_tools import check_widom_convergence, check_gcmc_convergence, check_gemc_convergence, check_gemc_box
-from .other_utilities import UnexpectedCalculationFailure, ErrorHandlerReport, prepare_process_inputs
+from .inspection_tools import check_widom_convergence, check_gcmc_convergence, check_gemc_convergence
+from .inspection_tools import check_gemc_box, add_write_binary_restart
+from .other_utilities import UnexpectedCalculationFailure, ErrorHandlerReport
+from .other_utilities import prepare_process_inputs, register_error_handler

--- a/aiida_raspa/utils/inspection_tools.py
+++ b/aiida_raspa/utils/inspection_tools.py
@@ -12,6 +12,13 @@ from .other_utilities import ErrorHandlerReport
 
 
 @calcfunction
+def add_write_binary_restart(input_dict, write_every=Int(100)):
+    final_dict = input_dict.get_dict()
+    final_dict["GeneralSettings"]["WriteBinaryRestartFileEvery"] = write_every
+    return input_dict if input_dict.get_dict() == final_dict else Dict(dict=final_dict)
+
+
+@calcfunction
 def modify_number_of_cycles(input_dict, additional_init_cycle, additional_prod_cycle):
     """Modify number of cycles to improve the convergence."""
     final_dict = input_dict.get_dict()

--- a/aiida_raspa/utils/inspection_tools.py
+++ b/aiida_raspa/utils/inspection_tools.py
@@ -12,7 +12,7 @@ from .other_utilities import ErrorHandlerReport
 
 
 @calcfunction
-def add_write_binary_restart(input_dict, write_every=Int(100)):
+def add_write_binary_restart(input_dict, write_every):
     final_dict = input_dict.get_dict()
     final_dict["GeneralSettings"]["WriteBinaryRestartFileEvery"] = write_every
     return input_dict if input_dict.get_dict() == final_dict else Dict(dict=final_dict)

--- a/aiida_raspa/utils/other_utilities.py
+++ b/aiida_raspa/utils/other_utilities.py
@@ -2,6 +2,7 @@
 """Other utilities."""
 from __future__ import absolute_import
 from collections import namedtuple
+from functools import wraps
 
 from aiida.common import AiidaException, AttributeDict
 from aiida.engine import ExitCode
@@ -11,6 +12,16 @@ from aiida.orm import Dict
 class UnexpectedCalculationFailure(AiidaException):
     """Raised when a calculation job has failed for an unexpected or unrecognized reason."""
 
+
+ErrorHandler = namedtuple('ErrorHandler', 'priority method')
+"""A namedtuple to define an error handler for a :class:`~aiida.engine.processes.workchains.workchain.WorkChain`.
+The priority determines in which order the error handling methods are executed, with
+the higher priority being executed first. The method defines an unbound WorkChain method
+that takes an instance of a :class:`~aiida.orm.nodes.process.calculations.calcjob.CalcJobNode`
+as its sole argument. If the condition of the error handler is met, it should return an :class:`.ErrorHandlerReport`.
+:param priority: integer denoting the error handlers priority
+:param method: the workchain class method
+"""
 
 ErrorHandlerReport = namedtuple('ErrorHandlerReport', 'is_handled do_break exit_code')
 ErrorHandlerReport.__new__.__defaults__ = (False, False, ExitCode())
@@ -69,3 +80,68 @@ def wrap_bare_dict_inputs(port_namespace, inputs):
             wrapped[key] = value
 
     return wrapped
+
+
+def register_error_handler(cls, priority=None):
+    """Decoraten any function in an error handler :class:`.BaseRestartWorkChain` sub classes.
+    The function expects two arguments, a workchain class and a priortity. The decorator will add the function as a
+    class method to the workchain class and add an :class:`.ErrorHandler` tuple to the
+    :attr:`.BaseRestartWorkChain._error_handlers` attribute of the workchain. During failed calculation handling the
+    :meth:`.inspect_calculation` outline method will call the `_handle_calculation_failure` which will loop over all
+    error handler in the :attr:`.BaseRestartWorkChain._error_handlers`, sorted with respect to the priority in reverse.
+    If the workchain class defines a :attr:`.BaseRestartWorkChain._verbose` attribute and is set to `True`, a report
+    message will be fired when the error handler is executed.
+    Requirements on the function signature of error handling functions. The function to which the
+    decorator is applied needs to take two arguments:
+        * `self`: This is the instance of the workchain itself
+        * `calculation`: This is the calculation that failed and needs to be investigated
+    The function body should usually consist of a single conditional that checks the calculation if
+    the error that it is designed to handle is applicable. Although not required, it is advised that
+    the function return an :class:`.ErrorHandlerReport` tuple when its conditional was met. If an error was handled
+    it should set `is_handled` to `True`. If no other error handlers should be considered set `do_break` to `True`.
+    :param cls: the workchain class to register the error handler with
+    :param priority: optional integer that defines the order in which registered handlers will be called
+        during the handling of a failed calculation. Higher priorities will be handled first. If the priority is `None`
+        the handler will not be automatically called during calculation failure handling. This is useful to define
+        handlers that one only wants to call manually, for example in the `_handle_sanity_checks` and still profit
+        from the other features of this decorator.
+    """
+
+    def error_handler_decorator(handler):
+        """Decorate a function to dynamically register an error handler to a `WorkChain` class."""
+
+        @wraps(handler)
+        def error_handler(self, calculation):
+            """Wrap error handler to add a log to the report if the handler is called and verbosity is turned on."""
+            if hasattr(cls, '_verbose') and cls._verbose:  # pylint: disable=protected-access
+                if priority:
+                    self.report('({}){}'.format(priority, handler.__name__))
+                else:
+                    self.report('{}'.format(handler.__name__))
+
+            result = handler(self, calculation)
+
+            # If a handler report is returned, attach the handler's name to node's attributes
+            if isinstance(result, ErrorHandlerReport):
+                try:
+                    errors_handled = self.node.get_extra('errors_handled', [])
+                    current_calculation = errors_handled[-1]
+                except IndexError:
+                    # The extra was never initialized, so we skip this functionality
+                    pass
+                else:
+                    # Append the name of the handler to the last list in `errors_handled` and save it
+                    current_calculation.append(handler.__name__)
+                    self.node.set_extra('errors_handled', errors_handled)
+
+            return result
+
+        setattr(cls, handler.__name__, error_handler)
+
+        if not hasattr(cls, '_error_handlers'):
+            cls._error_handlers = []  # pylint: disable=protected-access
+        cls._error_handlers.append(ErrorHandler(priority, error_handler))  # pylint: disable=protected-access
+
+        return error_handler
+
+    return error_handler_decorator

--- a/aiida_raspa/workchains/aiida_base_restart.py
+++ b/aiida_raspa/workchains/aiida_base_restart.py
@@ -187,10 +187,11 @@ class BaseRestartWorkChain(WorkChain):
             exit_code = self._handle_unexpected_failure(calculation, exception)
 
         # If the exit code returned actually has status `0` that means we consider the calculation as successful
-        if isinstance(exit_code, ExitCode) and exit_code.status == 0:
-            self.ctx.is_finished = True
-
-        return exit_code
+        if isinstance(exit_code, ExitCode):
+            if  exit_code.status == 0:
+                self.report('What am I doing here?')
+                self.ctx.is_finished = True
+            return exit_code
 
     def results(self):
         """Attach the outputs specified in the output specification from the last completed calculation."""

--- a/aiida_raspa/workchains/aiida_base_restart.py
+++ b/aiida_raspa/workchains/aiida_base_restart.py
@@ -189,7 +189,6 @@ class BaseRestartWorkChain(WorkChain):
         # If the exit code returned actually has status `0` that means we consider the calculation as successful
         if isinstance(exit_code, ExitCode):
             if  exit_code.status == 0:
-                self.report('What am I doing here?')
                 self.ctx.is_finished = True
             return exit_code
 

--- a/aiida_raspa/workchains/base.py
+++ b/aiida_raspa/workchains/base.py
@@ -40,7 +40,7 @@ class RaspaBaseWorkChain(BaseRestartWorkChain):
         super(RaspaBaseWorkChain, self).setup()
         self.ctx.inputs = AttributeDict(self.exposed_inputs(RaspaCalculation, 'raspa'))
         if "WriteBinaryRestartFileEvery" not in self.ctx.inputs.parameters["GeneralSettings"]:
-            self.ctx.inputs.parameters = add_write_binary_restart(self.ctx.inputs.parameters, Int(100))
+            self.ctx.inputs.parameters = add_write_binary_restart(self.ctx.inputs.parameters, Int(1000))
 
     def report_error_handled(self, calculation, action):
         """Report an action taken for a calculation that has failed.

--- a/aiida_raspa/workchains/base.py
+++ b/aiida_raspa/workchains/base.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 from aiida.common import AttributeDict
 from aiida.engine import while_
+from aiida.orm import Int
 from aiida.plugins import CalculationFactory
 
 from aiida_raspa.utils import ErrorHandlerReport, register_error_handler, add_write_binary_restart
@@ -39,7 +40,7 @@ class RaspaBaseWorkChain(BaseRestartWorkChain):
         super(RaspaBaseWorkChain, self).setup()
         self.ctx.inputs = AttributeDict(self.exposed_inputs(RaspaCalculation, 'raspa'))
         if "WriteBinaryRestartFileEvery" not in self.ctx.inputs.parameters["GeneralSettings"]:
-            self.ctx.inputs.parameters = add_write_binary_restart(self.ctx.inputs.parameters)
+            self.ctx.inputs.parameters = add_write_binary_restart(self.ctx.inputs.parameters, Int(100))
 
     def report_error_handled(self, calculation, action):
         """Report an action taken for a calculation that has failed.

--- a/aiida_raspa/workchains/base.py
+++ b/aiida_raspa/workchains/base.py
@@ -56,11 +56,8 @@ class RaspaBaseWorkChain(BaseRestartWorkChain):
 @register_error_handler(RaspaBaseWorkChain, 570)
 def _handle_timeout(self, calculation):
     """Error handler that restarts calculation finished with TIMEOUT ExitCode."""
-    self.report_error_handled(calculation, "Entering timeout handler.")
-    self.report_error_handled(calculation, calculation.exit_status)
     if calculation.exit_status == RaspaCalculation.spec().exit_codes.TIMEOUT.status:
-        self.report_error_handled(calculation, "Registering binary restart.")
+        self.report_error_handled(calculation, "Timeout handler. Adding remote folder as input to use binary restart.")
         self.ctx.inputs.parent_folder = calculation.outputs.remote_folder
-    self.report_error_handled(calculation, "Restarting calc time out.")
 
     return ErrorHandlerReport(True, False, None)

--- a/aiida_raspa/workchains/base.py
+++ b/aiida_raspa/workchains/base.py
@@ -6,6 +6,7 @@ from aiida.common import AttributeDict
 from aiida.engine import while_
 from aiida.plugins import CalculationFactory
 
+from aiida_raspa.utils import ErrorHandlerReport, register_error_handler, add_write_binary_restart
 from aiida_raspa.workchains.aiida_base_restart import BaseRestartWorkChain
 
 RaspaCalculation = CalculationFactory('raspa')  # pylint: disable=invalid-name
@@ -37,3 +38,28 @@ class RaspaBaseWorkChain(BaseRestartWorkChain):
         """
         super(RaspaBaseWorkChain, self).setup()
         self.ctx.inputs = AttributeDict(self.exposed_inputs(RaspaCalculation, 'raspa'))
+        if "WriteBinaryRestartFileEvery" not in self.ctx.inputs.parameters["GeneralSettings"]:
+            self.ctx.inputs.parameters = add_write_binary_restart(self.ctx.inputs.parameters)
+
+    def report_error_handled(self, calculation, action):
+        """Report an action taken for a calculation that has failed.
+        This should be called in a registered error handler if its condition is met and an action was taken.
+        :param calculation: the failed calculation node
+        :param action: a string message with the action taken
+        """
+        arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
+        self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
+        self.report('Action taken: {}'.format(action))
+
+
+@register_error_handler(RaspaBaseWorkChain, 570)
+def _handle_timeout(self, calculation):
+    """Error handler that restarts calculation finished with TIMEOUT ExitCode."""
+    self.report_error_handled(calculation, "Entering timeout handler.")
+    self.report_error_handled(calculation, calculation.exit_status)
+    if calculation.exit_status == RaspaCalculation.spec().exit_codes.TIMEOUT.status:
+        self.report_error_handled(calculation, "Registering binary restart.")
+        self.ctx.inputs.parent_folder = calculation.outputs.remote_folder
+    self.report_error_handled(calculation, "Restarting calc time out.")
+
+    return ErrorHandlerReport(True, False, None)

--- a/examples/workchains/example_base_restart_timeout.py
+++ b/examples/workchains/example_base_restart_timeout.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Two-component GCMC through RaspaBaseWorkChain"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+import os
+import sys
+import click
+
+from aiida.common import NotExistent
+from aiida.engine import run
+from aiida.orm import CifData, Code, Dict, SinglefileData
+from aiida_raspa.workchains import RaspaBaseWorkChain
+
+
+def example_base_workchain_gcmc(raspa_code):
+    """Run base workchain for GCMC calculations with 2 components."""
+
+    # pylint: disable=no-member
+
+    print("Testing RASPA Xenon:Krypton GCMC through RaspaBaseWorkChain ...")
+
+    parameters = Dict(
+        dict={
+            "GeneralSettings": {
+                "SimulationType": "MonteCarlo",
+                "NumberOfCycles": 10000,
+                "NumberOfInitializationCycles": 5000,
+                "PrintEvery": 10,
+                "Forcefield": "GenericMOFs",
+                "RemoveAtomNumberCodeFromLabel": True,
+                "EwaldPrecision": 1e-6,
+                "CutOff": 12.0,
+            },
+            "System": {
+                "irmof_1": {
+                    "type": "Framework",
+                    "UnitCells": "1 1 1",
+                    "HeliumVoidFraction": 0.149,
+                    "ExternalTemperature": 300.0,
+                    "ExternalPressure": 1e5,
+                }
+            },
+            "Component": {
+                "krypton": {
+                    "MoleculeDefinition": "TraPPE",
+                    "TranslationProbability": 0.5,
+                    "ReinsertionProbability": 0.5,
+                    "SwapProbability": 1.0,
+                    "BlockPocketsFileName": {
+                        "irmof_1": "irmof_1_krypton",
+                    },
+                },
+            },
+        })
+
+    # framework
+    pwd = os.path.dirname(os.path.realpath(__file__))
+    structure = CifData(file=os.path.join(pwd, '..', 'files', 'IRMOF-1.cif'))
+    structure_label = "irmof_1"
+
+    block_pocket_node1 = SinglefileData(file=os.path.join(pwd, '..', 'files', 'IRMOF-1_test.block')).store()
+
+    # Constructing builder
+    builder = RaspaBaseWorkChain.get_builder()
+
+    # Specifying the code
+    builder.raspa.code = raspa_code
+
+    # Specifying the framework
+    builder.raspa.framework = {
+        structure_label: structure,
+    }
+
+    # Specifying the input parameters
+    builder.raspa.parameters = parameters
+
+    # Specifying the block pockets
+    builder.raspa.block_pocket = {
+        "irmof_1_krypton": block_pocket_node1,
+    }
+
+    # Specifying the scheduler options
+    builder.raspa.metadata.options = {
+        "resources": {
+            "num_machines": 1,
+            "num_mpiprocs_per_machine": 1,
+        },
+        "max_wallclock_seconds": 1 * 30 * 60,  # 30 min
+        "withmpi": True,
+        "mpirun_extra_params": ["timeout", "10"],
+    }
+
+    run(builder)
+
+
+@click.command('cli')
+@click.argument('codelabel')
+def cli(codelabel):
+    """Click interface"""
+    try:
+        code = Code.get_from_string(codelabel)
+    except NotExistent:
+        print("The code '{}' does not exist".format(codelabel))
+        sys.exit(1)
+    example_base_workchain_gcmc(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter
+
+# EOF


### PR DESCRIPTION
That includes
* Input plugin: add new exit codes: ERROR_SIMULATION_DID_NOT_START and TIMEOUT

* Output parser: detect when (a) simulation did not start (b) did not reach the end

* Utilities: add add_write_binary_restart and register_error_handler

* BaseRestartWorkChain: exit only if error handler returns ExitCode

* RaspaBaseWorkChain: add _handle_timeout error handler