### PR TITLE
Add pycifrw as required dependency.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+parallel=True

--- a/setup.json
+++ b/setup.json
@@ -16,7 +16,8 @@
     "setup_requires": ["reentry"],
     "reentry_register": true,
     "install_requires": [
-        "aiida-core>=1.0.0,<2.0.0"
+        "aiida-core>=1.0.0,<2.0.0",
+        "pycifrw"
     ],
     "entry_points": {
         "aiida.calculations": [


### PR DESCRIPTION
Pycifrw is an optional dependency of aiida-core: https://github.com/aiidateam/aiida-core/blob/d44dcbd47a52c30f976fd6c15d17c052741d7b20/setup.json#L78
but for `aiida-raspa` it must be present.